### PR TITLE
feat: support ~ character at end of token to disable facial recognition

### DIFF
--- a/draw-canvas.js
+++ b/draw-canvas.js
@@ -52,14 +52,21 @@ const imageCodeFetch = async (url) => {
 let fallbackTokenImage;
 const fetchTokenImageAsBase64 = async (code) => {
   if (!code) return null;
+  const noFacial = code[code.length - 1] === '~';
+  const c = noFacial ? code.slice(0, code.length - 1) : code;
 
   try {
-    return await base64Fetch(`https://token.otfbm.io/face/${code}`);
+    if (noFacial) {
+      const err = new Error('User requested no facial recognition');
+      err.status = 404;
+      throw err;
+    }
+    return await base64Fetch(`https://token.otfbm.io/face/${c}`);
   } catch (err) {
     // swallow error and try img instead of face
     if (err.status === 404) {
       try {
-        return await base64Fetch(`https://token.otfbm.io/img/${code}`);
+        return await base64Fetch(`https://token.otfbm.io/img/${c}`);
       } catch (err) {
         // noop
       }

--- a/draw-canvas.js
+++ b/draw-canvas.js
@@ -52,25 +52,21 @@ const imageCodeFetch = async (url) => {
 let fallbackTokenImage;
 const fetchTokenImageAsBase64 = async (code) => {
   if (!code) return null;
-  const noFacial = code[code.length - 1] === '~';
-  const c = noFacial ? code.slice(0, code.length - 1) : code;
+  const useFacialRecognition = code[code.length - 1] !== '~';
+  const c = useFacialRecognition ? code:  code.slice(0, code.length - 1);
+
+  if (useFacialRecognition) {
+    try {
+      return await base64Fetch(`https://token.otfbm.io/face/${c}`);
+    } catch (err) {
+      // noop
+    }
+  }
 
   try {
-    if (noFacial) {
-      const err = new Error('User requested no facial recognition');
-      err.status = 404;
-      throw err;
-    }
-    return await base64Fetch(`https://token.otfbm.io/face/${c}`);
+    return await base64Fetch(`https://token.otfbm.io/img/${c}`);
   } catch (err) {
-    // swallow error and try img instead of face
-    if (err.status === 404) {
-      try {
-        return await base64Fetch(`https://token.otfbm.io/img/${c}`);
-      } catch (err) {
-        // noop
-      }
-    }
+    // noop
   }
 
   if (!fallbackTokenImage) {

--- a/parsers/token.js
+++ b/parsers/token.js
@@ -7,7 +7,7 @@ module.exports = class TokenParser {
     if (str.length < 2) return false;
 
     // a string matching a token definition eg. D3rp-asdsa
-    const reg = /^([A-Z]{1,2}[0-9]{1,2})([TSMLHG]*?)(PK|PU|BK|GY|BN|[WKEARGBYPCNOI]|~[0-9A-f]{6}|~[0-9A-f]{3})?(-([^~]+))?(~(.+))?$/i;
+    const reg = /^([A-Z]{1,2}[0-9]{1,2})([TSMLHG]*?)(PK|PU|BK|GY|BN|[WKEARGBYPCNOI]|~[0-9A-f]{6}|~[0-9A-f]{3})?(-([^~]+))?(~([a-z0-9]+~?))?$/i;
     if (reg.test(str)) {
       const matches = str.match(reg);
 


### PR DESCRIPTION
Makes it possible to turn off facial recognition on tokens by adding an additional ~ character at the end of the token

Eg. 

Default (will try facial recognition)
```
/a2-satyr~wcqj3/
```

Disable token facial recognition
```
/a2-satyr~wcqj3~/
```