### PR TITLE
Allow overlays to be underlays

### DIFF
--- a/board.js
+++ b/board.js
@@ -440,9 +440,14 @@ module.exports = class Board {
     }
   }
 
-  drawEffects() {
-    for (let effect of this.effects)
-      effect.draw(this.ctx, this.gridsize);
+  drawEffects({ under = false } = {}) {
+    for (let effect of this.effects) {
+      if (under === true) {
+        if (effect.under) effect.draw(this.ctx, this.gridsize);
+      } else {
+        if (!effect.under) effect.draw(this.ctx, this.gridsize);
+      }
+    }
   }
 
   drawFog() {

--- a/draw-canvas.js
+++ b/draw-canvas.js
@@ -304,6 +304,8 @@ module.exports = async function main(pathname, query, metrics = false) {
     grid.add(overlay);
   }
 
+  board.drawEffects({ under: true });
+
   for (const cell of grid) {
     renderer.renderOverlay(cell);
   }

--- a/parsers/effect-parser.js
+++ b/parsers/effect-parser.js
@@ -11,18 +11,21 @@ const effectShapes = new Map([
   ["L", "line"],
   ["S", "square"],
   ["R", "rectangle"],
-  ["A", "arrow"]
+  ["A", "arrow"],
 ]);
+
+const decorateUnder = (obj, under) => {
+  obj.under = !!under;
+  return obj;
+}
 
 module.exports = class EffectParser {
   parse(str) {
     let trimmed = str.toUpperCase();
-    if (trimmed.charAt(0) !== '*')
-      return false;
+    if (trimmed.charAt(0) !== "*") return false;
 
-    const reg = /\*([TLSRCA])([OT]?)([0-9]*)(\,[0-9]*)?(PK|PU|GY|BK|BN|[WKEARGBYPCNOI]|~[0-9A-F]{6}|~[0-9A-F]{3})?(([A-Z]{1,2}[0-9]{1,2})+)/;
-    if (!reg.test(trimmed)) 
-      return false;
+    const reg = /\*([TLSRCA])([OT]?)([0-9]*)(\,[0-9]*)?(PK|PU|GY|BK|BN|[WKEARGBYPCNOI]|~[0-9A-F]{6}|~[0-9A-F]{3})?(([A-Z]{1,2}[0-9]{1,2})+)(_)?/;
+    if (!reg.test(trimmed)) return false;
 
     const matches = trimmed.match(reg);
     let shape = effectShapes.get(matches[1]);
@@ -30,25 +33,70 @@ module.exports = class EffectParser {
     let size = matches[3];
     let colour = ColourParser.parse(matches[5]);
     let coords = CoordParser.parseSet(matches[6]);
+    const renderUnder = matches[8];
 
     switch (shape) {
       case "triangle":
-        return new TriangleEffect({ size, colour, startPt: coords[0], endPt: coords[1] });
+        return decorateUnder(
+          new TriangleEffect({
+            size,
+            colour,
+            startPt: coords[0],
+            endPt: coords[1],
+          }),
+          renderUnder
+        );
       case "circle":
-        return new CircleEffect({size, colour, anchorPt: coords[0], anchorType});
+        return decorateUnder(
+          new CircleEffect({ size, colour, anchorPt: coords[0], anchorType }),
+          renderUnder
+        );
       case "square":
-        if (anchorType !== 'T' && coords.length >= 2)
-          return new SquareEffect({width: size, length:size, colour, startPt: coords[0], endPt: coords[1], anchorTopLeft: false});  
-        return new SquareEffect({width: size, length:size, colour, startPt: coords[0], endPt: null, anchorTopLeft: true});
+        if (anchorType !== "T" && coords.length >= 2)
+          return decorateUnder(
+            new SquareEffect({
+              width: size,
+              length: size,
+              colour,
+              startPt: coords[0],
+              endPt: coords[1],
+              anchorTopLeft: false,
+            }),
+            renderUnder
+          );
+        return decorateUnder(
+          new SquareEffect({
+            width: size,
+            length: size,
+            colour,
+            startPt: coords[0],
+            endPt: null,
+            anchorTopLeft: true,
+          }),
+          renderUnder
+        );
       case "rectangle":
       case "line":
         let size2 = matches[4] ? matches[4].substr(1) : 5;
-        return new SquareEffect({width: size2, length:size, colour, startPt: coords[0], endPt: coords[1], anchorTopLeft: false}); 
+        return decorateUnder(
+          new SquareEffect({
+            width: size2,
+            length: size,
+            colour,
+            startPt: coords[0],
+            endPt: coords[1],
+            anchorTopLeft: false,
+          }),
+          renderUnder
+        );
       case "arrow":
         if (coords.length === 2)
-          return new ArrowEffect({ colour, startPt: coords[0], endPt: coords[1] });
+          return decorateUnder(
+            new ArrowEffect({ colour, startPt: coords[0], endPt: coords[1] }),
+            renderUnder
+          );
         break;
     }
     return false;
   }
-}
+};

--- a/parsers/effect-parser.js
+++ b/parsers/effect-parser.js
@@ -17,7 +17,7 @@ const effectShapes = new Map([
 const decorateUnder = (obj, under) => {
   obj.under = !!under;
   return obj;
-}
+};
 
 module.exports = class EffectParser {
   parse(str) {
@@ -35,68 +35,69 @@ module.exports = class EffectParser {
     let coords = CoordParser.parseSet(matches[6]);
     const renderUnder = matches[8];
 
+    let overlay;
     switch (shape) {
       case "triangle":
-        return decorateUnder(
-          new TriangleEffect({
-            size,
-            colour,
-            startPt: coords[0],
-            endPt: coords[1],
-          }),
-          renderUnder
-        );
+        overlay = new TriangleEffect({
+          size,
+          colour,
+          startPt: coords[0],
+          endPt: coords[1],
+        });
+        break;
       case "circle":
-        return decorateUnder(
-          new CircleEffect({ size, colour, anchorPt: coords[0], anchorType }),
-          renderUnder
-        );
+        overlay = new CircleEffect({
+          size,
+          colour,
+          anchorPt: coords[0],
+          anchorType,
+        });
+        break;
       case "square":
-        if (anchorType !== "T" && coords.length >= 2)
-          return decorateUnder(
-            new SquareEffect({
-              width: size,
-              length: size,
-              colour,
-              startPt: coords[0],
-              endPt: coords[1],
-              anchorTopLeft: false,
-            }),
-            renderUnder
-          );
-        return decorateUnder(
-          new SquareEffect({
+        if (anchorType !== "T" && coords.length >= 2) {
+          overlay = new SquareEffect({
             width: size,
-            length: size,
-            colour,
-            startPt: coords[0],
-            endPt: null,
-            anchorTopLeft: true,
-          }),
-          renderUnder
-        );
-      case "rectangle":
-      case "line":
-        let size2 = matches[4] ? matches[4].substr(1) : 5;
-        return decorateUnder(
-          new SquareEffect({
-            width: size2,
             length: size,
             colour,
             startPt: coords[0],
             endPt: coords[1],
             anchorTopLeft: false,
-          }),
-          renderUnder
-        );
+          });
+          break;
+        }
+        overlay = new SquareEffect({
+          width: size,
+          length: size,
+          colour,
+          startPt: coords[0],
+          endPt: null,
+          anchorTopLeft: true,
+        });
+        break;
+      case "rectangle":
+      case "line":
+        let size2 = matches[4] ? matches[4].substr(1) : 5;
+        overlay = new SquareEffect({
+          width: size2,
+          length: size,
+          colour,
+          startPt: coords[0],
+          endPt: coords[1],
+          anchorTopLeft: false,
+        });
+        break;
       case "arrow":
-        if (coords.length === 2)
-          return decorateUnder(
-            new ArrowEffect({ colour, startPt: coords[0], endPt: coords[1] }),
-            renderUnder
-          );
+        if (coords.length === 2) {
+          overlay = new ArrowEffect({
+            colour,
+            startPt: coords[0],
+            endPt: coords[1],
+          });
+        }
         break;
     }
-    return false;
+    if (!overlay) return false;
+
+    return decorateUnder(overlay, renderUnder);
   }
 };

--- a/parsers/effect-parser.js
+++ b/parsers/effect-parser.js
@@ -24,16 +24,16 @@ module.exports = class EffectParser {
     let trimmed = str.toUpperCase();
     if (trimmed.charAt(0) !== "*") return false;
 
-    const reg = /\*([TLSRCA])([OT]?)([0-9]*)(\,[0-9]*)?(PK|PU|GY|BK|BN|[WKEARGBYPCNOI]|~[0-9A-F]{6}|~[0-9A-F]{3})?(([A-Z]{1,2}[0-9]{1,2})+)(_)?/;
+    const reg = /\*(U)?([TLSRCA])([OT]?)([0-9]*)(\,[0-9]*)?(PK|PU|GY|BK|BN|[WKEARGBYPCNOI]|~[0-9A-F]{6}|~[0-9A-F]{3})?(([A-Z]{1,2}[0-9]{1,2})+)/;
     if (!reg.test(trimmed)) return false;
 
     const matches = trimmed.match(reg);
-    let shape = effectShapes.get(matches[1]);
-    let anchorType = matches[2];
-    let size = matches[3];
-    let colour = ColourParser.parse(matches[5]);
-    let coords = CoordParser.parseSet(matches[6]);
-    const renderUnder = matches[8];
+    const renderUnder = matches[1];
+    let shape = effectShapes.get(matches[2]);
+    let anchorType = matches[3];
+    let size = matches[4];
+    let colour = ColourParser.parse(matches[6]);
+    let coords = CoordParser.parseSet(matches[7]);
 
     let overlay;
     switch (shape) {
@@ -76,7 +76,7 @@ module.exports = class EffectParser {
         break;
       case "rectangle":
       case "line":
-        let size2 = matches[4] ? matches[4].substr(1) : 5;
+        let size2 = matches[5] ? matches[5].substr(1) : 5;
         overlay = new SquareEffect({
           width: size2,
           length: size,


### PR DESCRIPTION
Adds syntax to allow effect overlays to be underlays instead. Just add the u character to the start of an effect segment. 

Eg.

overlay (default)
```
https://otfbm.io/*c20rd5
```

underlay
```
https://otfbm.io/*uc20rd5
```