### PR TITLE
changes to incorporate meta?url= endpoint

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -10,9 +10,11 @@ resource "aws_api_gateway_deployment" "prod" {
     aws_api_gateway_resource.background_url,
     aws_api_gateway_integration.token_integration,
     aws_api_gateway_method.token_method,
+    aws_api_gateway_method.token_root_method,
     aws_api_gateway_resource.token_action,
     aws_api_gateway_resource.token_url,
-  aws_api_gateway_rest_api.gateway]
+    aws_api_gateway_integration.token_root_integration,
+    aws_api_gateway_rest_api.gateway]
   stage_name = "prod"
 
   rest_api_id = aws_api_gateway_rest_api.gateway.id

--- a/terraform/background.tf
+++ b/terraform/background.tf
@@ -275,6 +275,6 @@ resource "aws_iam_role_policy_attachment" "bg_lambda" {
 }
 
 resource "aws_iam_role_policy_attachment" "bg_lamba_basicexecutionrole" {
-  role       = "${aws_iam_role.bg_lambda.name}"
+  role       = aws_iam_role.bg_lambda.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }


### PR DESCRIPTION
Currently the token endpoint is available at `meta/{base64 of url}`. This PR adds functionality for `meta?url={url}`. This probably should be two properly different endpoints, and should be rewritten if and when we move to something more general use like a web app.