### PR TITLE
Add headers to download_img to help with imgur calls

### DIFF
--- a/background/background.py
+++ b/background/background.py
@@ -41,7 +41,7 @@ def lambda_handler(event, context):
 
 
 def download_img(buffer, url):
-    resp = requests.get(url, stream=True)
+    resp = requests.get(url, stream=True, headers={"user-agent": "curl/8.1.1"})
     # TODO err handling
     if resp.status_code == 200:
         for chunk in resp:

--- a/parsers/background.js
+++ b/parsers/background.js
@@ -8,7 +8,9 @@ export default class BackgroundParser {
       const pathname = Buffer.from(bg).toString("base64");
       const bgBaseURL = "https://bg.otfbm.io";
       // const res = await fetch(new URL(pathname, bgBaseURL));
-      const res = await fetch(bg);
+      const res = await fetch(bg, {
+        headers: {"user-agent": "curl/8.1.1"}
+      });
 
       const contentLength = res.headers.get("content-length");
       // if (contentLength > 1102000) {

--- a/token/otfbm-token.py
+++ b/token/otfbm-token.py
@@ -134,7 +134,7 @@ def convert_alpha(buffer):
 
 
 def download_img(buffer, url):
-    resp = requests.get(url, stream=True)
+    resp = requests.get(url, stream=True, headers={"user-agent": "curl/8.1.1"})
     # TODO err handling
     if resp.status_code == 200:
         for chunk in resp:


### PR DESCRIPTION
Added {"user-agent": "curl/8.1.1"} to help with the 429 - api limit errors imgur is returning.